### PR TITLE
fix(ahk): run_detached AttributeError crash (self.executable -> self._executable + None guard)

### DIFF
--- a/navig/adapters/automation/ahk.py
+++ b/navig/adapters/automation/ahk.py
@@ -149,8 +149,8 @@ NAVIG will automatically detect it in standard locations.
         self,
         script_path_or_content: Path | str,
         is_file: bool = True,
-        args: list[str] = None,
-        timeout: float = None,
+        args: list[str] | None = None,
+        timeout: float | None = None,
     ) -> ExecutionResult:
         if not self._executable:
             return ExecutionResult(False, stderr="AutoHotkey executable not found")
@@ -212,7 +212,7 @@ NAVIG will automatically detect it in standard locations.
                 duration_seconds=time.time() - start_time,
             )
 
-    def execute(self, code: str, timeout: float = None, force: bool = False) -> ExecutionResult:
+    def execute(self, code: str, timeout: float | None = None, force: bool = False) -> ExecutionResult:
         """Execute inline AHK code."""
         # Wrap in V2 requirement and provide a lightweight JSON shim for inline scripts.
         # Some inline snippets use JSON.stringify(...), which is not built into AHK v2.
@@ -272,17 +272,17 @@ NAVIG will automatically detect it in standard locations.
         return self._run_ahk_subprocess(full_code, is_file=False, timeout=timeout)
 
     def execute_file(
-        self, script_path: Path, args: list[str] = None, timeout: float = None
+        self, script_path: Path, args: list[str] | None = None, timeout: float | None = None
     ) -> ExecutionResult:
         """Execute an AHK script file."""
         return self._run_ahk_subprocess(script_path, is_file=True, args=args, timeout=timeout)
 
-    def run_detached(self, script_path: Path, args: list[str] = None) -> int:
+    def run_detached(self, script_path: Path, args: list[str] | None = None) -> int:
         """Run script in background (detached). Returns PID."""
-        if not self.executable.exists():
+        if not self._executable or not self._executable.exists():
             return 0
 
-        cmd = [str(self.executable), str(script_path)]
+        cmd = [str(self._executable), str(script_path)]
         if args:
             cmd.extend(args)
 

--- a/tests/ahk/test_ahk_run_detached_guard.py
+++ b/tests/ahk/test_ahk_run_detached_guard.py
@@ -1,0 +1,9 @@
+"""Regression: run_detached must not crash when the AHK executable is absent."""
+from pathlib import Path
+from navig.adapters.automation.ahk import AHKAdapter
+
+
+def test_run_detached_returns_zero_when_executable_missing() -> None:
+    adapter = AHKAdapter.__new__(AHKAdapter)
+    adapter._executable = None
+    assert adapter.run_detached(Path("noop.ahk")) == 0


### PR DESCRIPTION
## P1 — crash

`AHKAdapter.run_detached` referenced `self.executable`, but the attribute is `self._executable: Path | None` (used everywhere else, e.g. the `if not self._executable` guard in `_run_ahk_subprocess`). So **every** call raised `AttributeError`; even with the name fixed it would `NoneType.exists()`-crash when AutoHotkey isn't installed.

```diff
-        if not self.executable.exists():
+        if not self._executable or not self._executable.exists():
             return 0
-        cmd = [str(self.executable), str(script_path)]
+        cmd = [str(self._executable), str(script_path)]
```

Also annotates the implicit-Optional `list[str]`/`float` defaults (mypy `no_implicit_optional`).

## Verify
`pytest tests/ahk/test_ahk_run_detached_guard.py` (added — asserts `run_detached` returns 0 instead of crashing when `_executable is None`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)