### PR TITLE
fix(core): config silently ignored (ConfigManager.get crash masked) + SAFE_MODE timeline crash

### DIFF
--- a/navig/file_history.py
+++ b/navig/file_history.py
@@ -195,19 +195,18 @@ class FileHistoryStore:
 
     def _is_enabled(self) -> bool:
         try:
-            from navig.config import get_config_manager
-            cfg = get_config_manager()
-            return bool(cfg.get("file_history.enabled", False))
-        except Exception:  # noqa: BLE001
+            from navig.core import Config
+            return bool(Config().get("file_history.enabled", False))
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("file_history enabled-check failed: %r", exc)
             return False
 
     def _resolve_cache_root(self) -> Path:
         if self._cache_dir is not None:
             return self._cache_dir
         try:
-            from navig.config import get_config_manager
-            cfg = get_config_manager()
-            custom = cfg.get("file_history.cache_dir")
+            from navig.core import Config
+            custom = Config().get("file_history.cache_dir")
             if custom:
                 p = Path(str(custom)).expanduser()
                 p.mkdir(parents=True, exist_ok=True)

--- a/navig/requests/registry.py
+++ b/navig/requests/registry.py
@@ -41,12 +41,12 @@ Answer = dict[str, Any]
 def _auto_dispatch_enabled() -> bool:
     """Best-effort read of the ai.auto_dispatch runtime flag."""
     try:
-        from navig.config import get_config_manager
+        from navig.core import Config
 
-        cfg = get_config_manager()
-        ai_cfg = (cfg.get("ai") or {}) if cfg else {}
+        ai_cfg = Config().get("ai") or {}
         return bool(ai_cfg.get("auto_dispatch", False))
-    except Exception:
+    except Exception as exc:
+        logger.debug("auto_dispatch flag read failed: %r", exc)
         return False
 
 

--- a/navig/ui/timeline.py
+++ b/navig/ui/timeline.py
@@ -40,7 +40,7 @@ def render_event_timeline(
                 print(f"  {title}", file=sys.stdout)
             for ev in events:
                 print(
-                    f"  {ev.timestamp}  {ev.icon_safe if SAFE_MODE else ev.icon}  {ev.label}  {ev.detail}",
+                    f"  {ev.timestamp}  {getattr(ev, 'icon_safe', ev.icon) if SAFE_MODE else ev.icon}  {ev.label}  {ev.detail}",
                     file=sys.stdout,
                 )
         except Exception:  # noqa: BLE001

--- a/tests/core/test_file_history_config_read.py
+++ b/tests/core/test_file_history_config_read.py
@@ -1,0 +1,17 @@
+"""Regression: file_history.enabled must be READ from config, not silently defaulted.
+
+Before the fix, _is_enabled() called ConfigManager.get (no such method) inside a
+bare `except Exception: return False`, so it was permanently False regardless of
+config. The fix uses Config().get(...), which actually reads the value.
+"""
+from navig.core import Config
+from navig.file_history import get_file_history_store
+
+
+def test_file_history_enabled_reflects_config(monkeypatch) -> None:
+    monkeypatch.setattr(
+        Config, "get",
+        lambda self, key, default=None, scope="merged":
+            True if key == "file_history.enabled" else default,
+    )
+    assert get_file_history_store()._is_enabled() is True


### PR DESCRIPTION
## P2 — silent failure (config ignored)

`file_history.py` and `requests/registry.py` call `get_config_manager().get(...)`, but **`ConfigManager` has no `.get` method** (runtime `AttributeError`). Both are inside a bare `except: return False`, so the error was **masked** — `file_history.enabled`, `file_history.cache_dir`, and `ai.auto_dispatch` were permanently defaulted **regardless of config**.

```diff
-            cfg = get_config_manager()
-            return bool(cfg.get("file_history.enabled", False))
-        except Exception:  # noqa: BLE001
-            return False
+            from navig.core import Config
+            return bool(Config().get("file_history.enabled", False))
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("file_history enabled-check failed: %r", exc)
+            return False
```

`Config().get(dotted, default)` is the real API (the same one `cloud/tailscale.py` uses for `.set`); failures now log instead of silently swallowing.

## P2 — crash (SAFE_MODE)

`ui/timeline.py` referenced `Event.icon_safe`, but the `Event` dataclass has only `.icon` -> `AttributeError` whenever `SAFE_MODE` is on. Fixed with `getattr(ev, 'icon_safe', ev.icon)`.

## Verify
`pytest tests/core/test_file_history.py tests/core/test_file_history_config_read.py tests/ui/test_ui_diff_timeline_prompts.py` (regression test added; asserts `file_history.enabled` reflects config — fails under the old code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)